### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/url-slug.cabal
+++ b/url-slug.cabal
@@ -24,7 +24,7 @@ extra-source-files:
 library
   build-depends:
     , aeson
-    , base                >=4.13.0.0 && <=4.18.0.0
+    , base                >=4.13.0.0 && <4.20
     , relude
     , text
     , unicode-transforms

--- a/url-slug.cabal
+++ b/url-slug.cabal
@@ -24,7 +24,7 @@ extra-source-files:
 library
   build-depends:
     , aeson
-    , base                >=4.13.0.0 && <4.20
+    , base                >=4.13.0.0 && <5
     , relude
     , text
     , unicode-transforms


### PR DESCRIPTION
This shifts the upper bound on the `base` package, closes #1.

I've built successfully with ghc-9.6.4 and ghc-9.8.2.